### PR TITLE
Update README with correct CRON interval

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,4 +22,4 @@ The tool separates the logic for running the export and the actual workspace dat
 
 ## How it works
 
-This repo contains a GitHub workflow that runs every hour and for every push to this repo. The workflow will execute the script which makes an export request to Notion, waits for it to finish and downloads the workspace content to a temporary directory. The workflow will then commit this directory to the repository configured in the repo secrets.
+This repo contains a GitHub workflow that runs every day and for every push to this repo. The workflow will execute the script which makes an export request to Notion, waits for it to finish and downloads the workspace content to a temporary directory. The workflow will then commit this directory to the repository configured in the repo secrets.

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ The tool separates the logic for running the export and the actual workspace dat
 8. Click the "Actions" tab on the forked repo and enable actions by clicking the button.
 9. On the left sidebar click the "Backup Notion Workspace" workflow. A notice will tell you that "Scheduled Actions" are disabled, so go ahead and click the button to enable them.
 10. Wait until the action runs for the first time or push a commit to the repo to trigger the first backup.
-11. Check your private repo to see that an automatic commit with your Notion workspace data has been made. Done 🙌
+11. Check your private repo to see that an automatic commit with your Notion workspace data has been made. Done  🙌
 
 ## How it works
 

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ The tool separates the logic for running the export and the actual workspace dat
 8. Click the "Actions" tab on the forked repo and enable actions by clicking the button.
 9. On the left sidebar click the "Backup Notion Workspace" workflow. A notice will tell you that "Scheduled Actions" are disabled, so go ahead and click the button to enable them.
 10. Wait until the action runs for the first time or push a commit to the repo to trigger the first backup.
-11. Check your private repo to see that an automatic commit with your Notion workspace data has been made. Done  🙌
+11. Check your private repo to see that an automatic commit with your Notion workspace data has been made. Done 🙌
 
 ## How it works
 


### PR DESCRIPTION
The `cron: "0 0 * * *"` schedule in `.github/workflows/backup.yml` means automatic backups per day, not per hour.