### PR TITLE
Fix 403 error by adding new API cookie

### DIFF
--- a/index.js
+++ b/index.js
@@ -48,10 +48,12 @@ const exportFromNotion = async (destination, format) => {
   console.log(`Started Export as task [${taskId}].\n`);
 
   let exportURL;
+  let fileTokenCookie;
   while (true) {
     await sleep(2);
     const {
       data: { results: tasks },
+      headers: { 'set-cookie': getTasksRequestCookies },
     } = await client.post(`getTasks`, { taskIds: [taskId] });
     const task = tasks.find((t) => t.id === taskId);
 
@@ -64,6 +66,9 @@ const exportFromNotion = async (destination, format) => {
 
     if (task.state === `success`) {
       exportURL = task.status.exportURL;
+      fileTokenCookie = getTasksRequestCookies.find((cookie) =>
+        cookie.includes("file_token="),
+      );
       console.log(`\nExport finished.`);
       break;
     }
@@ -73,6 +78,9 @@ const exportFromNotion = async (destination, format) => {
     method: `GET`,
     url: exportURL,
     responseType: `stream`,
+    headers: {
+      Cookie: fileTokenCookie,
+    },
   });
 
   const size = response.headers["content-length"];


### PR DESCRIPTION
Add a new fileToken cookie based on the latest Notion API update. Changes are based on https://github.com/upleveled/notion-backup/pull/205

fixes https://github.com/richartkeil/notion-guardian/issues/11