### PR TITLE
Fix large zip file export error by using Git LFS

### DIFF
--- a/.github/workflows/backup.yml
+++ b/.github/workflows/backup.yml
@@ -41,6 +41,13 @@ jobs:
           cd backup-repo
           git config --local user.email "${REPO_EMAIL}"
           git config --local user.name "${REPO_USERNAME}"
+
+          # Fix large zip file export error by using Git LFS.
+          sudo apt install git-lfs
+          git lfs install
+          git lfs track "*.zip"
+          git add .gitattributes 
+
           git add .
           if [ -z "$(git status --porcelain)" ]; then
             exit 0

--- a/.github/workflows/backup.yml
+++ b/.github/workflows/backup.yml
@@ -37,6 +37,15 @@ jobs:
           REPO_EMAIL: ${{ secrets.REPO_EMAIL }}
           REPO_USERNAME: ${{ secrets.REPO_USERNAME }}
         run: |
+          # Overwrite zip files, because the limit of git lfs is 1G.
+          cd workspace
+          count=1
+          for file in *.zip; do
+            mv "$file" "Export-$count.zip"
+            count=$((count+1))
+          done
+          cd ..
+
           cp -a workspace/. backup-repo/
           cd backup-repo
           git config --local user.email "${REPO_EMAIL}"


### PR DESCRIPTION
fixes: https://github.com/richartkeil/notion-guardian/issues/10
If the exported zip file size is more than 100M, the script will fail, as mentioned in the #10 
Git LFS can solve this problem as follows:
1. set up the "my-concept-backup" repository, see [Managing Git LFS objects in archives](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/managing-git-lfs-objects-in-archives-of-your-repository#managing-git-lfs-objects-in-archives)
2. add the following code to backup.yml，see [backup.yml](https://github.com/Dragonliu2018/Keenster-notion-guardian/blob/dragonliu/fix_large_zip_file/.github/workflows/backup.yml)
    ```yml
          # Fix large zip file export error by using Git LFS.
          sudo apt install git-lfs
          git lfs install
          git lfs track "*.zip"
          git add .gitattributes 
    ```
After this, you should be able to push large zip file into Github.